### PR TITLE
Add test when colorbar is empty

### DIFF
--- a/silx/gui/plot/test/testColorBar.py
+++ b/silx/gui/plot/test/testColorBar.py
@@ -26,9 +26,10 @@
 
 __authors__ = ["H. Payno"]
 __license__ = "MIT"
-__date__ = "03/04/2017"
+__date__ = "11/04/2017"
 
 import unittest
+from silx.gui.test.utils import TestCaseQt
 from silx.gui.plot.Colorbar import Gradation
 from silx.gui.plot.Colorbar import ColorbarWidget
 from silx.gui.plot import Plot1D
@@ -159,10 +160,11 @@ class TestNoAutoscale(unittest.TestCase):
         val = self.gradation.getValueFromRelativePosition(0.0)
         self.assertTrue(val == -4.0)
 
-class TestColorbarWidget(unittest.TestCase):
+class TestColorbarWidget(TestCaseQt):
     """Test interaction with the GradationBar"""
 
     def setUp(self):
+        super(TestColorbarWidget, self).setUp()
         self.plot = Plot1D()
         self.colorBar = ColorbarWidget(parent=None, plot=self.plot)
 
@@ -172,6 +174,12 @@ class TestColorbarWidget(unittest.TestCase):
         self.colorBar = None
         self.plot.deleteLater()
         self.plot = None
+        super(TestColorbarWidget, self).tearDown()
+
+    def testEmptyColorBar(self):
+        colorBar = ColorbarWidget(parent=None)
+        colorBar.show()
+        self.qWaitForWindowExposed(colorBar)
 
     def testNegativeColormaps(self):
         """test the behavior of the ColorbarWidget in the case of negative


### PR DESCRIPTION
The colorbar should be able to be OK if there is no colorbar

I was needed to fix the `TestCaseQt` to catch uncatched exception

Here is the output:
```
AssertionError: Exception occured in Qt thread:
Traceback (most recent call last):
  File "/workspace/valls/silx.git/build/lib.linux-x86_64-2.7/silx/gui/plot/Colorbar.py", line 410, in resizeEvent
    self._updateMinMax()
  File "/workspace/valls/silx.git/build/lib.linux-x86_64-2.7/silx/gui/plot/Colorbar.py", line 387, in _updateMinMax
    if GradationBar._MIN_LIM_SCI_FORM <= self.minVal <= GradationBar._MAX_LIM_SCI_FORM:
AttributeError: 'GradationBar' object has no attribute 'minVal'
Traceback (most recent call last):
  File "/workspace/valls/silx.git/build/lib.linux-x86_64-2.7/silx/gui/plot/Colorbar.py", line 494, in paintEvent
    vmin = self.colormap['vmin']
TypeError: 'NoneType' object has no attribute '__getitem__'
```

The use of `TestCaseQt` also show that the widget do not release very well the memories, or test have to be fixed.
```
RuntimeError: Test ended with widgets alive: [<PyQt4.QtGui.QPushButton object at 0x7f23bcd7d478>, <PyQt4.QtGui.QToolButton object at 0x7f23bcd7d3e0>, <PyQt4.QtGui.QLabel object at 0x7f23bcd7d348>, <PyQt4.QtGui.QMenu object at 0x7f23bcd7d510>, <PyQt4.QtGui.QLabel object at 0x7f23b3948348>, <PyQt4.QtGui.QToolButton object at 0x7f23bcd7d5a8>, <PyQt4.QtGui.QWidget object at 0x7f23bcd7d770>, <silx.gui.plot.Colorbar._VerticalLegend object at 0x7f23b39483e0>, <PyQt4.QtGui.QWidget object at 0x7f23bcd7d808>, <PyQt4.QtGui.QLabel object at 0x7f23bcd7d8a0>, <PyQt4.QtGui.QTabBar object at 0x7f23bcd7d938>, <PyQt4.QtGui.QWidget object at 0x7f23b3939c30>, <PyQt4.QtGui.QScrollBar object at 0x7f23bcd7d9d0>, <PyQt4.QtGui.QToolButton object at 0x7f23bcd7da68>, <PyQt4.QtGui.QToolButton object at 0x7f23bcd7db00>, <PyQt4.QtGui.QWidget object at 0x7f23bcd7db98>, <PyQt4.QtGui.QMenu object at 0x7f23bcd7dd60>, <PyQt4.QtGui.QLabel object at 0x7f23bcd7ddf8>, <PyQt4.QtGui.QWidget object at 0x7f23bcd7de90>, <PyQt4.QtGui.QLabel object at 0x7f23bcd7dcc8>, <PyQt4.QtGui.QScrollBar object at 0x7f23bcd7dc30>, <PyQt4.QtGui.QWidget object at 0x7f23bcd7df28>, <PyQt4.QtGui.QPushButton object at 0x7f23bcd7d6d8>, <PyQt4.QtGui.QAbstractButton object at 0x7f23bcd7d640>, <PyQt4.QtGui.QToolButton object at 0x7f23b3939050>, <PyQt4.QtGui.QToolButton object at 0x7f23b39390e8>, <PyQt4.QtGui.QPushButton object at 0x7f23b3939180>, <PyQt4.QtGui.QToolButton object at 0x7f23b3939218>, <PyQt4.QtGui.QToolButton object at 0x7f23b39392b0>, <PyQt4.QtGui.QWidget object at 0x7f23b3939348>, <PyQt4.QtGui.QToolButton object at 0x7f23b39393e0>, <PyQt4.QtGui.QAbstractButton object at 0x7f23b3939478>, <PyQt4.QtGui.QWidget object at 0x7f23b3939d60>, <PyQt4.QtGui.QToolButton object at 0x7f23b3939510>, <PyQt4.QtGui.QWidget object at 0x7f23b39395a8>, <PyQt4.QtGui.QPushButton object at 0x7f23b3939770>, <PyQt4.QtGui.QToolButton object at 0x7f23b3939808>, <PyQt4.QtGui.QWidget object at 0x7f23b3939640>, <PyQt4.QtGui.QWidget object at 0x7f23b39396d8>, <PyQt4.QtGui.QTableWidget object at 0x7f23b39398a0>, <silx.gui.plot.Colorbar.TickBar object at 0x7f23b3948180>, <PyQt4.QtGui.QWidget object at 0x7f23b3939938>, <PyQt4.QtGui.QWidget object at 0x7f23b39399d0>, <silx.gui.plot.Colorbar.Gradation object at 0x7f23b3948050>, <PyQt4.QtGui.QScrollBar object at 0x7f23b3939a68>, <silx.gui.plot.Colorbar.ColorbarWidget object at 0x7f23b3939b00>, <PyQt4.QtGui.QToolButton object at 0x7f23b39485a8>, <PyQt4.QtGui.QScrollBar object at 0x7f23b3948510>, <PyQt4.QtGui.QWidget object at 0x7f23b39486d8>, <PyQt4.QtGui.QDockWidget object at 0x7f23b3948770>, <PyQt4.QtGui.QWidget object at 0x7f23b3948808>, <PyQt4.QtGui.QHeaderView object at 0x7f23b39488a0>, <silx.gui.plot.Colorbar.GradationBar object at 0x7f23b3939e90>, <PyQt4.QtGui.QLabel object at 0x7f23b39482b0>, <PyQt4.QtGui.QToolButton object at 0x7f23b3948938>, <PyQt4.QtGui.QWidget object at 0x7f23b39489d0>, <PyQt4.QtGui.QMenu object at 0x7f23b3948a68>, <PyQt4.QtGui.QToolBar object at 0x7f23b3948b00>, <PyQt4.QtGui.QToolButton object at 0x7f23b3948b98>, <PyQt4.QtGui.QToolButton object at 0x7f23b3948c30>, <PyQt4.QtGui.QLabel object at 0x7f23b3948cc8>, <PyQt4.QtGui.QRubberBand object at 0x7f23b3948d60>, <PyQt4.QtGui.QToolButton object at 0x7f23b3948df8>, <PyQt4.QtGui.QToolButton object at 0x7f23b3948e90>, <PyQt4.QtGui.QWidget object at 0x7f23b3948f28>, <PyQt4.QtGui.QWidget object at 0x7f23b23c9050>, <PyQt4.QtGui.QToolButton object at 0x7f23b23c90e8>, <PyQt4.QtGui.QScrollBar object at 0x7f23b23c9180>, <PyQt4.QtGui.QAbstractButton object at 0x7f23b23c9218>, <PyQt4.QtGui.QMainWindow object at 0x7f23b23c92b0>, <PyQt4.QtGui.QWidget object at 0x7f23b23c9348>, <PyQt4.QtGui.QLabel object at 0x7f23b23c93e0>, <PyQt4.QtGui.QWidget object at 0x7f23b23c9478>, <PyQt4.QtGui.QWidget object at 0x7f23b23c9510>, <PyQt4.QtGui.QToolButton object at 0x7f23b23c95a8>, <PyQt4.QtGui.QLabel object at 0x7f23b23c9640>, <PyQt4.QtGui.QToolButton object at 0x7f23b23c96d8>, <PyQt4.QtGui.QScrollBar object at 0x7f23b23c9770>, <PyQt4.QtGui.QHeaderView object at 0x7f23b23c9808>, <PyQt4.QtGui.QLabel object at 0x7f23b23c98a0>, <PyQt4.QtGui.QWidget object at 0x7f23b23c9938>, <PyQt4.QtGui.QToolButton object at 0x7f23b23c99d0>, <PyQt4.QtGui.QPushButton object at 0x7f23b23c9a68>, <PyQt4.QtGui.QWidget object at 0x7f23b23c9b00>, <PyQt4.QtGui.QToolButton object at 0x7f23b23c9b98>, <PyQt4.QtGui.QToolButton object at 0x7f23b23c9c30>, <PyQt4.QtGui.QWidget object at 0x7f23b23c9cc8>]
```