### PR TITLE
Update of silx PR #762

### DIFF
--- a/doc/source/modules/gui/plot/items.rst
+++ b/doc/source/modules/gui/plot/items.rst
@@ -26,7 +26,6 @@ Images
    :members:
    :inherited-members:
 
-
 Scatter
 -------
 
@@ -34,6 +33,12 @@ Scatter
    :members:
    :inherited-members:
 
+Histogram
+---------
+
+.. autoclass:: Histogram
+   :members:
+   :inherited-members:
 
 Markers
 -------

--- a/doc/source/modules/gui/plot/plotwidget.rst
+++ b/doc/source/modules/gui/plot/plotwidget.rst
@@ -34,6 +34,8 @@ Those methods allow to add and update plotted data:
 
 .. automethod:: PlotWidget.addCurve
 .. automethod:: PlotWidget.addImage
+.. automethod:: PlotWidget.addScatter
+.. automethod:: PlotWidget.addHistogram
 
 Plot markers
 ............
@@ -160,7 +162,8 @@ The :class:`PlotWidget` provides the following Qt signals:
    getActiveCurve, setActiveCurve,
    isCurveHidden, hideCurve,
    getActiveImage, setActiveImage,
-   getAllCurves, getCurve, getMonotonicCurves, getImage,
+   getAllCurves, getCurve, getImage, getAllImages,
+   getScatter, getHistogram,
    setDefaultPlotPoints, setDefaultPlotLines,
    getWidgetHandle, notify, setCallback, graphCallback,
    dataToPixel, pixelToData, getPlotBoundsInPixels,

--- a/silx/gui/plot/PlotActions.py
+++ b/silx/gui/plot/PlotActions.py
@@ -1241,21 +1241,16 @@ class PixelIntensitiesHistoAction(PlotAction):
 
             data = image.ravel().astype(numpy.float32)
             histogram = Histogramnd(data, n_bins=nbins, histo_range=data_range)
-            assert(len(histogram.edges) == 1)
+            assert len(histogram.edges) == 1
             self._histo = histogram.histo
-            x = numpy.arange(nbins) * (xmax - xmin) / nbins + xmin
-            y = self._histo
+            edges = histogram.edges[0]
             plot = self.getHistogramPlotWidget()
-            plot.addCurve(
-                x=x,
-                y=y,
-                legend='pixel intensity',
-                fill=True,
-                color='red',
-                histogram='center')
-
-            colormap = self.plot.getDefaultColormap()
-            plot.setXAxisLogarithmic(colormap["normalization"] == "log")
+            plot.addHistogram(histogram=self._histo,
+                              edges=edges,
+                              legend='pixel intensity',
+                              fill=True,
+                              color='red')
+            plot.resetZoom()
 
     def eventFilter(self, qobject, event):
         """Observe when the close event is emitted then

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -96,7 +96,8 @@ class PlotWidget(qt.QMainWindow, Plot.Plot):
     It provides 3 informations:
 
     - action: The change of the plot: 'add' or 'remove'
-    - kind: The kind of primitive changed: 'curve', 'image', 'item' or 'marker'
+    - kind: The kind of primitive changed:
+      'curve', 'image', 'scatter', 'histogram', 'item' or 'marker'
     - legend: The legend of the primitive changed.
     """
 

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -54,6 +54,7 @@ from matplotlib.collections import PathCollection, LineCollection
 from .ModestImage import ModestImage
 from . import BackendBase
 from .. import Colors
+from .._utils import FLOAT32_MINPOS
 
 
 class BackendMatplotlib(BackendBase.BackendBase):
@@ -178,7 +179,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
             if fill:
                 artists.append(axes.fill_between(
-                    x, 1.0e-8, y, facecolor=actualColor[0], linestyle=''))
+                    x, FLOAT32_MINPOS, y, facecolor=actualColor[0], linestyle=''))
 
         else:  # Curve
             curveList = axes.plot(x, y,
@@ -193,7 +194,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
             if fill:
                 artists.append(
-                    axes.fill_between(x, 1.0e-8, y, facecolor=color))
+                    axes.fill_between(x, FLOAT32_MINPOS, y, facecolor=color))
 
         for artist in artists:
             artist.set_zorder(z)

--- a/silx/gui/plot/items/__init__.py
+++ b/silx/gui/plot/items/__init__.py
@@ -34,9 +34,9 @@ __date__ = "06/03/2017"
 
 from .core import (Item, LabelsMixIn, DraggableMixIn, ColormapMixIn,  # noqa
                    SymbolMixIn, ColorMixIn, YAxisMixIn, FillMixIn,  # noqa
-                   AlphaMixIn)  # noqa
+                   AlphaMixIn, LineMixIn)  # noqa
 from .curve import Curve  # noqa
-from .histogram import Histogram
+from .histogram import Histogram  # noqa
 from .image import ImageBase, ImageData, ImageRgba  # noqa
 from .shape import Shape  # noqa
 from .scatter import Scatter  # noqa

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -379,6 +379,66 @@ class SymbolMixIn(object):
             self._updated()
 
 
+class LineMixIn(object):
+    """Mix-in class for item with line"""
+
+    _DEFAULT_LINEWIDTH = 1.
+    """Default line width"""
+
+    _DEFAULT_LINESTYLE = '-'
+    """Default line style"""
+
+    def __init__(self):
+        self._linewidth = self._DEFAULT_LINEWIDTH
+        self._linestyle = self._DEFAULT_LINESTYLE
+
+    def getLineWidth(self):
+        """Return the curve line width in pixels (int)"""
+        return self._linewidth
+
+    def setLineWidth(self, width):
+        """Set the width in pixel of the curve line
+
+        See :meth:`getLineWidth`.
+
+        :param float width: Width in pixels
+        """
+        width = float(width)
+        if width != self._linewidth:
+            self._linewidth = width
+            self._updated()
+
+    def getLineStyle(self):
+        """Return the type of the line
+
+        Type of line::
+
+            - ' '  no line
+            - '-'  solid line
+            - '--' dashed line
+            - '-.' dash-dot line
+            - ':'  dotted line
+
+        :rtype: str
+        """
+        return self._linestyle
+
+    def setLineStyle(self, style):
+        """Set the style of the curve line.
+
+        See :meth:`getLineStyle`.
+
+        :param str style: Line style
+        """
+        style = str(style)
+        assert style in ('', ' ', '-', '--', '-.', ':', None)
+        if style is None:
+            style = self._DEFAULT_LINESTYLE
+        if style != self._linestyle:
+            self._linestyle = style
+            self._updated()
+
+
 class ColorMixIn(object):
     """Mix-in class for item with color"""
 
@@ -749,8 +809,9 @@ class Points(Item, SymbolMixIn, AlphaMixIn):
         """
         x = numpy.array(x, copy=copy)
         y = numpy.array(y, copy=copy)
-        self._checkXYDim(x, y)
-        self._checkXYLength(x, y)
+        assert len(x) == len(y)
+        assert x.ndim == y.ndim == 1
+
         if xerror is not None:
             xerror = numpy.array(xerror, copy=copy)
         if yerror is not None:
@@ -769,9 +830,3 @@ class Points(Item, SymbolMixIn, AlphaMixIn):
             plot = self.getPlot()
             if plot is not None:
                 plot._invalidateDataRange()
-
-    def _checkXYLength(self, x, y):
-        assert len(x) == len(y)
-
-    def _checkXYDim(self, x, y):
-        assert x.ndim == y.ndim == 1

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -36,14 +36,14 @@ import numpy
 
 from .. import Colors
 from .core import (Points, LabelsMixIn, SymbolMixIn,
-                   ColorMixIn, YAxisMixIn, FillMixIn)
+                   ColorMixIn, YAxisMixIn, FillMixIn, LineMixIn)
 from ....utils.decorators import deprecated
 
 
 _logger = logging.getLogger(__name__)
 
 
-class Curve(Points, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn):
+class Curve(Points, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixIn):
     """Description of a curve"""
 
     _DEFAULT_Z_LAYER = 1
@@ -67,10 +67,7 @@ class Curve(Points, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn):
         YAxisMixIn.__init__(self)
         FillMixIn.__init__(self)
         LabelsMixIn.__init__(self)
-
-        self._linewidth = self._DEFAULT_LINEWIDTH
-        self._linestyle = self._DEFAULT_LINESTYLE
-        self._histogram = None
+        LineMixIn.__init__(self)
 
         self._highlightColor = self._DEFAULT_HIGHLIGHT_COLOR
         self._highlighted = False
@@ -195,49 +192,3 @@ class Curve(Points, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn):
             return self.getHighlightedColor()
         else:
             return self.getColor()
-
-    def getLineWidth(self):
-        """Return the curve line width in pixels (int)"""
-        return self._linewidth
-
-    def setLineWidth(self, width):
-        """Set the width in pixel of the curve line
-
-        See :meth:`getLineWidth`.
-
-        :param float width: Width in pixels
-        """
-        width = float(width)
-        if width != self._linewidth:
-            self._linewidth = width
-            self._updated()
-
-    def getLineStyle(self):
-        """Return the type of the line
-
-        Type of line::
-
-            - ' '  no line
-            - '-'  solid line
-            - '--' dashed line
-            - '-.' dash-dot line
-            - ':'  dotted line
-
-        :rtype: str
-        """
-        return self._linestyle
-
-    def setLineStyle(self, style):
-        """Set the style of the curve line.
-
-        See :meth:`getLineStyle`.
-
-        :param str style: Line style
-        """
-        style = str(style)
-        assert style in ('', ' ', '-', '--', '-.', ':', None)
-        if style is None:
-            style = self._DEFAULT_LINESTYLE
-        if style != self._linestyle:
-            self._linestyle = style
-            self._updated()


### PR DESCRIPTION
Continuation of ``Histogram`` object:
- ``Histogram`` inherits from ``Item`` rather than ``Curve``
- Added a ``LineMixIn`` class
- Added ``Plot.addHistogram`` + ``Plot.getHistogram``
- Fix in matplotlib backend curve fill 'almost zero' value
- Updated ``PixelIntensityHistogramAction``
- Updated doc

A few remarks:
- I minimized the number of arguments to ``addHistogram``: no info, z, linestyle, etc... which can be set on the object afterwards in order to have the method signature simple.
- If the ``Histogram`` is created with as many edges as values (i.e., missing one edge), the missing edge is computed depending on the ``align`` attribute (left, right or center (default)) and the computed bin edges are stored in the object and NOT what the user provided...

 Any opinion on those choices?